### PR TITLE
Now retains non-completed results in hashmap when sweeping

### DIFF
--- a/backend/webserver/src/endpoints/haskell.rs
+++ b/backend/webserver/src/endpoints/haskell.rs
@@ -18,7 +18,7 @@ pub async fn submit(
         submission: exercise_submission,
         result: None 
     };
-    
+
     state.job_results.lock().unwrap().insert(id, None);
     
     let _res = state.tx.send(work).await;
@@ -31,7 +31,7 @@ pub async fn get_test_runner_result(
     Path(id) : Path<Uuid>,
     Extension(state): Extension<Arc<State>>,
 ) -> Json<Value> {
-    let mut map = state.job_results.lock().unwrap();
+    let map = state.job_results.lock().unwrap();
     
     if !map.contains_key(&id) {
         // UUID not contained in hashmap at all
@@ -46,8 +46,7 @@ pub async fn get_test_runner_result(
     }
 
     let result = work.clone().unwrap();
-    map.remove(&id);
-    
+
     Json(json!({
         "status": "complete",
         "success": result.success,

--- a/backend/webserver/src/services/worker.rs
+++ b/backend/webserver/src/services/worker.rs
@@ -41,6 +41,12 @@ async fn worker_thread(
             println!("Sweeping now...");
 
             map.retain(|&_, res| {
+                // If there is no test runner result associated with the given UUID, keep the
+                // element because no result has been produced yet.
+                if res.is_none() {
+                    return true
+                }
+
                 res.as_ref().unwrap().timestamp.elapsed().unwrap() <= config.lifetime
             });
             


### PR DESCRIPTION
Co-Authored-By: Pattrigue <57709490+Pattrigue@users.noreply.github.com>

# What was implemented
A catch for retaining None values.

# Explanation
Added a catch for hashmap when result was none (representing a non-completed haskell test).

# Outcome
Bugfix
